### PR TITLE
Add Layer Search + Ontario Road Network layer to lio_list

### DIFF
--- a/lio_list.py
+++ b/lio_list.py
@@ -110,5 +110,6 @@ lio_list = [
     ['23', 'Forest Resource Inventory Status', '07'],
     ['25', 'Provincially Tracked Species 1km Grid', '07'],
     ['29', 'Wooded Area', '07'],
+    ['0', 'Ontario Road Network', '09']
 
     ]


### PR DESCRIPTION
Added the layer search bar functionality to the plugin (same functionality in my last PR to the geohub_services standalone script)

Added the Ontario Road Network Layer to the lio_list - https://geohub.lio.gov.on.ca/datasets/mnrf::ontario-road-network-orn-road-net-element/about

If you've tested the plugin and everything is working okay for you - lets start using this repo for development and stop updating the standalone geohub_services.py repo?